### PR TITLE
Updated invalid_mut to without_provenance_mut due to recent change in Rust Nightly

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -265,7 +265,7 @@ impl<A: Alignment> Default for AlignedBytes<A> {
             // Use strict pointer functions if enabled.
             // See https://github.com/V0ldek/aligners/issues/34
             #[cfg(miri)]
-            let raw_ptr = std::ptr::invalid_mut(A::size());
+            let raw_ptr = std::ptr::without_provenance_mut(A::size());
             #[cfg(not(miri))]
             let raw_ptr = A::size() as *mut u8;
 


### PR DESCRIPTION
Aligners to no longer compiles with miri due to `std::ptr::invalid_mut` being renamed to `without_provenance_mut ` in this [commit](https://github.com/rust-lang/rust/commit/d579caf384b752715663f481f944f60cbae35a3e). 

I've fixed the affected code. All test pass with `cargo miri test`